### PR TITLE
Update license with AMPO copyright

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2014, Synthicity, LLC.
+Copyright (c) 2014-2015, Association of Metropolitan Planning Organizations
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
I changed the copyright assignee to "Association of Metropolitan Planning Organizations". @waddell is that the correct entity?