### PR TITLE
new other_than function

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,10 @@ install:
 - >
   conda create -q -c synthicity -n test-environment
   python=$TRAVIS_PYTHON_VERSION
-  ipython-notebook jinja2 matplotlib numpy pandas pandana patsy pip pytables
-  pytest pyyaml scipy statsmodels toolz
+  cytoolz ipython-notebook jinja2 matplotlib numpy pandas pandana patsy pip
+  pytables pytest pyyaml scipy statsmodels toolz
 - source activate test-environment
-- pip install simplejson bottle prettytable
+- pip install bottle prettytable simplejson zbox
 - pip install https://github.com/synthicity/urbansim/archive/master.zip
 - pip install openmatrix
 - pip install pytest-cov coveralls pep8

--- a/activitysim/activitysim.py
+++ b/activitysim/activitysim.py
@@ -267,31 +267,31 @@ def interaction_simulate(
     return pd.Series(choices, index=choosers.index), model_design
 
 
-def other_than(data, bools):
+def other_than(groups, bools):
     """
     Construct a Series that has booleans indicating the presence of
     something- or someone-else with a certain property within a group.
 
     Parameters
     ----------
-    data : pandas.Series
-        A column with the same index as `bools` that has some property
-        to be tallied for the purposes of detecting others. The `bools`
-        Series will be used to index `data` and then values will be counted.
+    groups : pandas.Series
+        A column with the same index as `bools` that defines the grouping
+        of `bools`. The `bools` Series will be used to index `groups` and
+        then the grouped values will be counted.
     bools : pandas.Series
         A boolean Series indicating where the property of interest is present.
-        Should have the same index as `data`.
+        Should have the same index as `groups`.
 
     Returns
     -------
     others : pandas.Series
-        A boolean Series with the same index as `data` and `bools`
+        A boolean Series with the same index as `groups` and `bools`
         indicating whether there is something- or something-else within
         a group with some property (as indicated by `bools`).
 
     """
-    counts = data[bools].value_counts()
-    merge_col = data.to_frame(name='right')
+    counts = groups[bools].value_counts()
+    merge_col = groups.to_frame(name='right')
     pipeline = tz.compose(
         tz.curry(pd.Series.fillna, value=False),
         itemgetter('left'),

--- a/activitysim/tests/test_other_than.py
+++ b/activitysim/tests/test_other_than.py
@@ -10,12 +10,14 @@ from ..activitysim import other_than
 def people():
     return pd.DataFrame({
         'household': [1, 2, 2, 3, 3, 3, 4, 4, 4, 4],
-        'ptype':     [1, 2, 1, 3, 1, 2, 3, 2, 2, 1]})
+        'ptype':     [1, 2, 1, 3, 1, 2, 3, 2, 2, 1]},
+        index=['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j'])
 
 
 def test_other_than(people):
     expected = pd.Series(
-        [False, False, True, True, True, False, True, True, True, True])
+        [False, False, True, True, True, False, True, True, True, True],
+        index=people.index)
 
     bools = people['ptype'] == 2
     others = other_than(people['household'], bools)

--- a/activitysim/tests/test_other_than.py
+++ b/activitysim/tests/test_other_than.py
@@ -1,0 +1,23 @@
+import pandas as pd
+import pandas.util.testing as pdt
+import pytest
+
+
+from ..activitysim import other_than
+
+
+@pytest.fixture(scope='module')
+def people():
+    return pd.DataFrame({
+        'household': [1, 2, 2, 3, 3, 3, 4, 4, 4, 4],
+        'ptype':     [1, 2, 1, 3, 1, 2, 3, 2, 2, 1]})
+
+
+def test_other_than(people):
+    expected = pd.Series(
+        [False, False, True, True, True, False, True, True, True, True])
+
+    bools = people['ptype'] == 2
+    others = other_than(people['household'], bools)
+
+    pdt.assert_series_equal(others, expected)

--- a/setup.py
+++ b/setup.py
@@ -18,10 +18,12 @@ setup(
     ],
     packages=find_packages(exclude=['*.tests']),
     install_requires=[
-        'numpy>=1.8.0',
-        'openmatrix>=0.2.2',
-        'pandas>=0.13.1',
-        'tables>=3.1.0',
-        'urbansim>=1.3'
+        'numpy >= 1.8.0',
+        'openmatrix >= 0.2.2',
+        'pandas >= 0.13.1',
+        'tables >= 3.1.0',
+        'toolz >= 0.7',
+        'urbansim >= 1.3',
+        'zbox >= 1.2'
     ]
 )


### PR DESCRIPTION
Allows you to test for the presence of something- or someone-else
within a group that has some property. For example, you can figure
out whether there is someone else within a household that has
a given person-type.

Fixes #22.

Using this, the current [`presence_of`](https://github.com/synthicity/activitysim/blob/254da40fe1acd175819533ffcb528a6e5d72053b/activitysim/defaults/tables/households.py#L166) function could be converted to:

```python
def presence_of(ptype, persons, at_home=False):
    if at_home:
        # if at_home, they need to be of given type AND at home
        bools = (persons.ptype_cat == ptype) & (persons.cdap_activity == "H")]
    else:
        bools = persons.ptype_cat == ptype

    return other_than(persons.household_id, bools)
```

Of course, the above `presence_of` would have to go on the `persons` table, where the linked one is on the `households` table.