### PR TITLE
allow nans in skim orig/dest indexes

### DIFF
--- a/activitysim/skim.py
+++ b/activitysim/skim.py
@@ -38,14 +38,28 @@ class Skim(object):
         values : 1D array
 
         """
+        # only working with numpy in here
         orig = np.asanyarray(orig)
         dest = np.asanyarray(dest)
+        out_shape = orig.shape
+
+        # filter orig and dest to only the real-number pairs
+        notnan = ~(np.isnan(orig) | np.isnan(dest))
+        orig = orig[notnan].astype('int')
+        dest = dest[notnan].astype('int')
 
         if self.offset:
             orig = orig + self.offset
             dest = dest + self.offset
 
-        return self.data[orig, dest]
+        result = self.data[orig, dest]
+
+        # add the nans back to the result
+        out = np.empty(out_shape)
+        out[notnan] = result
+        out[~notnan] = np.nan
+
+        return out
 
 
 class Skims(object):

--- a/activitysim/tests/test_skim.py
+++ b/activitysim/tests/test_skim.py
@@ -34,3 +34,14 @@ def test_offset(data):
     npt.assert_array_equal(
         sk.get(orig, dest),
         [52, 99, 16])
+
+
+def test_skim_nans(data):
+    sk = skim.Skim(data)
+
+    orig = [5, np.nan, 1, 2]
+    dest = [np.nan, 9, 6, 4]
+
+    npt.assert_array_equal(
+        sk.get(orig, dest),
+        [np.nan, np.nan, 16, 24])


### PR DESCRIPTION
A nan is returned as the impedence value any time either the origin or destination is nan.