### PR TITLE
CDAP Performance Improvements

### DIFF
--- a/activitysim/cdap/cdap.py
+++ b/activitysim/cdap/cdap.py
@@ -214,21 +214,20 @@ def apply_final_rules(hh_util, people, hh_id_col, final_rules):
     for hh_id, df in people.groupby(hh_id_col, sort=False):
         mask = rule_mask.loc[df.index]
         utils = hh_util[hh_id]
+        hh_size = len(df)
 
         for exp, row in final_rules.iterrows():
             m = mask[exp].as_matrix()
+            alt = np.array([row.iloc[0]] * hh_size)
 
             # this crazy business combines three things to figure out
             # which household alternatives need to be modified by this rule.
             # the three things are:
             # - the mask of people for whom the rule expression is true (m)
             # - the individual alternative to which the rule applies
-            #   (row.iloc[0])
+            #   (alt)
             # - the alternative combinations for the household (combo)
-            app = [
-                ((np.array([row.iloc[0]] * len(utils.index[0])) == combo) & m
-                 ).any()
-                for combo in utils.index]
+            app = [((alt == combo) & m).any() for combo in utils.index]
 
             utils[app] = row.iloc[1]
 

--- a/activitysim/cdap/cdap.py
+++ b/activitysim/cdap/cdap.py
@@ -267,9 +267,7 @@ def apply_final_rules(hh_util, people, hh_id_col, final_rules):
             if key in alt_match_cache:
                 alt_match = alt_match_cache[key]
             else:
-                alt_match = (
-                    np.array(utils.index.values.tolist()) ==
-                    np.array([alt] * hh_size))
+                alt_match = np.array(utils.index.values.tolist()) == alt
                 alt_match_cache[key] = alt_match
 
             app = np.any(np.bitwise_and(alt_match, m), axis=1)

--- a/activitysim/cdap/cdap.py
+++ b/activitysim/cdap/cdap.py
@@ -243,7 +243,10 @@ def apply_final_rules(hh_util, people, hh_id_col, final_rules):
             # - the individual alternative to which the rule applies
             #   (alt)
             # - the alternative combinations for the household (combo)
-            app = [((alt == combo) & m).any() for combo in utils.index]
+            app = np.any(
+                np.bitwise_and(
+                    (np.array(utils.index.values.tolist()) == alt), m),
+                axis=1)
 
             utils[app] = row.iloc[1]
 

--- a/activitysim/cdap/cdap.py
+++ b/activitysim/cdap/cdap.py
@@ -165,7 +165,6 @@ def initial_household_utilities(utilities, people, hh_id_col):
     combo_cache = {}
 
     for hh_id, df in people.groupby(hh_id_col, sort=False):
-        utils = utilities.loc[df.index]
         hh_size = len(df)
 
         if hh_size in combo_cache:
@@ -175,7 +174,7 @@ def initial_household_utilities(utilities, people, hh_id_col):
             flat_combos = list(tz.concat(combos))
             combo_cache[hh_size] = (combos, flat_combos)
 
-        u = utils.lookup(
+        u = utilities.lookup(
             np.tile(df.index.values, len(combos)), flat_combos)
         u = u.reshape((len(combos), hh_size)).sum(axis=1)
 

--- a/activitysim/cdap/cdap.py
+++ b/activitysim/cdap/cdap.py
@@ -180,7 +180,6 @@ def initial_household_utilities(utilities, people, hh_id_col):
     hh_util = {}
 
     alts = utilities.columns
-    alts_map = {a: i for i, a in enumerate(alts)}
     combo_cache = {}
 
     for hh_id, df in people.groupby(hh_id_col, sort=False):
@@ -191,7 +190,8 @@ def initial_household_utilities(utilities, people, hh_id_col):
             ncombos, combos, flat_combos, tiled = combo_cache[hh_size]
         else:
             combos = list(itertools.product(alts, repeat=hh_size))
-            flat_combos = [alts_map[a] for a in tz.concat(combos)]
+            flat_combos = list(
+                tz.concat(itertools.product(range(len(alts)), repeat=hh_size)))
             ncombos = len(combos)
             tiled = np.tile(np.arange(hh_size), ncombos)
             combo_cache[hh_size] = (ncombos, combos, flat_combos, tiled)

--- a/activitysim/cdap/cdap.py
+++ b/activitysim/cdap/cdap.py
@@ -188,15 +188,15 @@ def initial_household_utilities(utilities, people, hh_id_col):
         utils = utilities.loc[df.index].as_matrix()
 
         if hh_size in combo_cache:
-            combos, flat_combos = combo_cache[hh_size]
+            ncombos, combos, flat_combos, tiled = combo_cache[hh_size]
         else:
             combos = list(itertools.product(alts, repeat=hh_size))
             flat_combos = [alts_map[a] for a in tz.concat(combos)]
-            combo_cache[hh_size] = (combos, flat_combos)
+            ncombos = len(combos)
+            tiled = np.tile(np.arange(hh_size), ncombos)
+            combo_cache[hh_size] = (ncombos, combos, flat_combos, tiled)
 
-        ncombos = len(combos)
-        u = (utils[np.tile(np.arange(hh_size), ncombos), flat_combos]
-             .reshape((ncombos, hh_size)).sum(axis=1))
+        u = utils[tiled, flat_combos].reshape((ncombos, hh_size)).sum(axis=1)
 
         hh_util[hh_id] = pd.Series(u, index=combos)
 

--- a/activitysim/cdap/cdap.py
+++ b/activitysim/cdap/cdap.py
@@ -213,13 +213,27 @@ def apply_final_rules(hh_util, people, hh_id_col, final_rules):
     """
     rule_mask = eval_variables(final_rules.index, people)
 
+    if not rule_mask.as_matrix().any():
+        # if the rules don't apply to anyone then return now
+        return
+
     for hh_id, df in people.groupby(hh_id_col, sort=False):
         mask = rule_mask.loc[df.index]
+        if not mask.as_matrix().any():
+            # if the mask doesn't apply to anyone in this household
+            # carry on to the next household
+            continue
+
         utils = hh_util[hh_id]
         hh_size = len(df)
 
         for exp, row in final_rules.iterrows():
             m = mask[exp].as_matrix()
+            if not m.any():
+                # if this sub-mask doesn't apply to anyone here then
+                # carry on to the next rule
+                continue
+
             alt = np.array([row.iloc[0]] * hh_size)
 
             # this crazy business combines three things to figure out

--- a/example/simulation.py
+++ b/example/simulation.py
@@ -1,0 +1,59 @@
+# coding: utf-8
+import orca
+from activitysim import defaults
+
+
+import pandas as pd
+import numpy as np
+import os
+orca.add_injectable("store", pd.HDFStore(
+        os.path.join("..", "activitysim", "defaults", "test", "test.h5"), "r"))
+orca.add_injectable("nonmotskm_matrix", np.ones((1454, 1454)))
+
+
+# In[4]:
+
+orca.run(["school_location_simulate"])
+
+
+# In[5]:
+
+orca.run(["workplace_location_simulate"])
+
+
+# In[7]:
+
+orca.run(["auto_ownership_simulate"])
+
+
+# In[8]:
+
+orca.run(["cdap_simulate"])
+
+
+# In[9]:
+
+orca.run(['mandatory_tour_frequency'])
+
+# In[11]:
+
+orca.run(["mandatory_scheduling"])
+
+
+# In[12]:
+
+orca.run(['non_mandatory_tour_frequency'])
+
+# In[14]:
+
+orca.run(["destination_choice"])
+
+
+# In[15]:
+
+orca.run(["non_mandatory_scheduling"])
+
+
+# In[16]:
+
+orca.run(['mode_choice_simulate'])


### PR DESCRIPTION
This drags improves performance in the CDAP functions `initial_household_utilities` and `apply_final_rules`. `apply_final_rules` is still slow enough that we plan to stop using the final rules and specify disallowed alternatives in the way it's done now, by putting large negative utilities in the single-person utilities.