### PR TITLE
Draw samples individually for choosers

### DIFF
--- a/activitysim/mnl.py
+++ b/activitysim/mnl.py
@@ -104,8 +104,9 @@ def interaction_dataset(choosers, alternatives, sample_size=None):
     alts_idx = np.arange(numalts)
 
     if sample_size < numalts:
-        sample = np.random.choice(
-            alts_idx, sample_size * numchoosers, replace=True)
+        sample = np.concatenate(tuple(
+            np.random.choice(alts_idx, sample_size, replace=False)
+            for _ in range(numchoosers)))
     else:
         sample = np.tile(alts_idx, numchoosers)
 

--- a/activitysim/tests/test_mnl.py
+++ b/activitysim/tests/test_mnl.py
@@ -121,9 +121,9 @@ def test_interaction_dataset_sampled(
         interaction_choosers, interaction_alts, random_seed):
     expected = pd.DataFrame({
         'attr': ['a'] * 2 + ['b'] * 2 + ['c'] * 2 + ['b'] * 2,
-        'prop': [10, 40, 20, 10, 40, 40, 40, 40],
+        'prop': [30, 40, 10, 30, 40, 10, 20, 10],
         'chooser_idx': ['w'] * 2 + ['x'] * 2 + ['y'] * 2 + ['z'] * 2},
-        index=[1, 4, 2, 1, 4, 4, 4, 4])
+        index=[3, 4, 1, 3, 4, 1, 2, 1])
 
     interacted = mnl.interaction_dataset(
         interaction_choosers, interaction_alts, sample_size=2)


### PR DESCRIPTION
When building an interaction dataset with sampling we
need to pick alternatives individually for each chooser
so that we don't draw the same alternative multiple times
for the same chooser.

Similar to https://github.com/synthicity/urbansim/commit/d17a5ced1aca84e9e0fce0249921255804d51a52.