### PR TITLE
use new sample_method name

### DIFF
--- a/activitysim/abm/test/test_location_choice.py
+++ b/activitysim/abm/test/test_location_choice.py
@@ -57,7 +57,7 @@ def test_estimation_override_preserves_destination_choice_logsum(monkeypatch):
     )
     state = SimpleNamespace(
         settings=SimpleNamespace(
-            sample_method="monte_carlo",
+            sample_method="inverse_cdf",
             trace_hh_id=None,
             use_explicit_error_terms=False,
         )


### PR DESCRIPTION
Looks like #1077 used the old sample_method name in one of the unit tests, it was recently updated without deprecation, see #1098. This should fix failing tests on main.